### PR TITLE
Add Flutter app skeleton with textbooks list and group chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# lokre
+# Lokre App
+
+هذا المشروع يمثل نواة تطبيق Flutter لملازم وكتب الصف الثالث المتوسط مع خاصية الدردشة الجماعية.
+
+## البنية
+- `pubspec.yaml`: تعريف الحزم المطلوبة.
+- `lib/main.dart`: نقطة الدخول للتطبيق.
+- `lib/screens/`: تحتوي الشاشات الأساسية:
+  - `home_screen.dart`
+  - `books_list.dart`
+  - `chat_room.dart`
+  - `pdf_viewer.dart`
+
+يمكن توسيع هذا المشروع بإضافة ملفات Firebase وتهيئة `firebase_options.dart` بالإضافة إلى استخدام مكتبات عرض ملفات PDF.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'screens/home_screen.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const LokreApp());
+}
+
+class LokreApp extends StatelessWidget {
+  const LokreApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lokre',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.blue,
+      ),
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/lib/screens/books_list.dart
+++ b/lib/screens/books_list.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'pdf_viewer.dart';
+
+class BooksList extends StatelessWidget {
+  BooksList({super.key});
+
+  final Stream<QuerySnapshot> _booksStream =
+      FirebaseFirestore.instance.collection('books').snapshots();
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: _booksStream,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(child: Text('حدث خطأ'));
+        }
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final docs = snapshot.data!.docs;
+        return GridView.builder(
+          padding: const EdgeInsets.all(8),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+          ),
+          itemCount: docs.length,
+          itemBuilder: (context, index) {
+            final book = docs[index];
+            return GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => PdfViewerScreen(
+                      url: book['downloadUrl'],
+                      tag: book.id,
+                    ),
+                  ),
+                );
+              },
+              child: Card(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Hero(
+                        tag: book.id,
+                        child: Image.network(
+                          book['thumbnailUrl'],
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      book['title'],
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/chat_room.dart
+++ b/lib/screens/chat_room.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class ChatRoom extends StatefulWidget {
+  const ChatRoom({super.key, required this.roomId});
+
+  final String roomId;
+
+  @override
+  State<ChatRoom> createState() => _ChatRoomState();
+}
+
+class _ChatRoomState extends State<ChatRoom> {
+  final TextEditingController _controller = TextEditingController();
+  late CollectionReference messagesRef;
+
+  @override
+  void initState() {
+    super.initState();
+    messagesRef = FirebaseFirestore.instance
+        .collection('chatRooms')
+        .doc(widget.roomId)
+        .collection('messages');
+  }
+
+  Future<void> _sendMessage() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null || _controller.text.trim().isEmpty) return;
+    await messagesRef.add({
+      'text': _controller.text.trim(),
+      'senderId': user.uid,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+    _controller.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('الدردشة')),
+      body: Column(
+        children: [
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: messagesRef.orderBy('timestamp').snapshots(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final messages = snapshot.data!.docs;
+                return ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    final msg = messages[index];
+                    return ListTile(
+                      title: Text(msg['text']),
+                      subtitle: Text(msg['senderId']),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          SafeArea(
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration:
+                        const InputDecoration(hintText: 'اكتب رسالة...'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _sendMessage,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'books_list.dart';
+import 'chat_room.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('كتب وملازم الصف الثالث')),
+      body: Column(
+        children: [
+          Expanded(child: BooksList()),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ChatRoom(roomId: 'general'),
+                  ),
+                );
+              },
+              child: const Text('الدردشة الجماعية'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/pdf_viewer.dart
+++ b/lib/screens/pdf_viewer.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class PdfViewerScreen extends StatelessWidget {
+  const PdfViewerScreen({super.key, required this.url, required this.tag});
+
+  final String url;
+  final Object tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('عرض الكتاب')),
+      body: Center(
+        child: Hero(
+          tag: tag,
+          child: Text('عرض PDF من: \$url'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,27 @@
+name: lokre_app
+description: Sample Flutter app for third grade textbooks with group chat.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.18.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  firebase_core: ^2.0.0
+  firebase_auth: ^4.0.0
+  cloud_firestore: ^4.0.0
+  firebase_storage: ^11.0.0
+  provider: ^6.0.0
+  animations: ^2.0.7
+
+# Dev dependencies
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- Scaffold Flutter project for third-grade textbooks with group chat
- Add Firebase-powered book list, chat room, and placeholder PDF viewer
- Document project structure and dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897275065c8832ab523525bdb8e2450