### PR TITLE
feat: add quiz and banner with book counter

### DIFF
--- a/lib/screens/books_list.dart
+++ b/lib/screens/books_list.dart
@@ -3,7 +3,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'pdf_viewer.dart';
 
 class BooksList extends StatelessWidget {
-  BooksList({super.key});
+  BooksList({super.key, required this.onBookOpened});
+
+  final VoidCallback onBookOpened;
 
   final Stream<QuerySnapshot> _booksStream =
       FirebaseFirestore.instance.collection('books').snapshots();
@@ -33,6 +35,7 @@ class BooksList extends StatelessWidget {
             final book = docs[index];
             return GestureDetector(
               onTap: () {
+                onBookOpened();
                 Navigator.push(
                   context,
                   MaterialPageRoute(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,10 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'books_list.dart';
 import 'chat_room.dart';
+import 'quiz_screen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final ValueNotifier<int> _openedBooks = ValueNotifier<int>(0);
 
   @override
   Widget build(BuildContext context) {
@@ -22,23 +32,102 @@ class HomeScreen extends StatelessWidget {
       ),
       body: Column(
         children: [
-          Expanded(child: BooksList()),
+          SizedBox(
+            height: 150,
+            child: const _BannerCarousel(),
+          ),
+          ValueListenableBuilder<int>(
+            valueListenable: _openedBooks,
+            builder: (context, value, _) => Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text('الكتب المفتوحة: $value'),
+            ),
+          ),
+          Expanded(
+            child: BooksList(
+              onBookOpened: () => _openedBooks.value++,
+            ),
+          ),
           Padding(
             padding: const EdgeInsets.all(16),
-            child: ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const ChatRoom(roomId: 'general'),
-                  ),
-                );
-              },
-              child: const Text('الدردشة الجماعية'),
+            child: Column(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const ChatRoom(roomId: 'general'),
+                      ),
+                    );
+                  },
+                  child: const Text('الدردشة الجماعية'),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const QuizScreen(),
+                      ),
+                    );
+                  },
+                  child: const Text('الاختبارات'),
+                ),
+              ],
             ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _BannerCarousel extends StatefulWidget {
+  const _BannerCarousel();
+
+  @override
+  State<_BannerCarousel> createState() => _BannerCarouselState();
+}
+
+class _BannerCarouselState extends State<_BannerCarousel> {
+  final PageController _controller = PageController();
+  int _currentPage = 0;
+  final List<String> _images = const [
+    'https://via.placeholder.com/400x150.png?text=Banner+1',
+    'https://via.placeholder.com/400x150.png?text=Banner+2',
+    'https://via.placeholder.com/400x150.png?text=Banner+3',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    Timer.periodic(const Duration(seconds: 5), (timer) {
+      if (!mounted) return;
+      _currentPage = (_currentPage + 1) % _images.length;
+      _controller.animateToPage(
+        _currentPage,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeIn,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+      controller: _controller,
+      itemCount: _images.length,
+      itemBuilder: (context, index) {
+        return Image.network(_images[index], fit: BoxFit.cover);
+      },
     );
   }
 }

--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class QuizScreen extends StatefulWidget {
+  const QuizScreen({super.key});
+
+  @override
+  State<QuizScreen> createState() => _QuizScreenState();
+}
+
+class _QuizScreenState extends State<QuizScreen> {
+  final List<_Question> _questions = const [
+    _Question(
+      text: 'كم عدد الكواكب في المجموعة الشمسية؟',
+      options: ['7', '8', '9', '10'],
+      answerIndex: 1,
+    ),
+    _Question(
+      text: 'ما نتيجة 5 × 3؟',
+      options: ['8', '15', '20', '25'],
+      answerIndex: 1,
+    ),
+  ];
+
+  int _current = 0;
+  int _score = 0;
+
+  void _answer(int index) {
+    if (_questions[_current].answerIndex == index) {
+      _score++;
+    }
+    if (_current < _questions.length - 1) {
+      setState(() => _current++);
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('النتيجة'),
+          content: Text('حصلت على $_score من ${_questions.length}'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                Navigator.pop(context);
+              },
+              child: const Text('حسناً'),
+            )
+          ],
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final q = _questions[_current];
+    return Scaffold(
+      appBar: AppBar(title: const Text('الاختبارات')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('السؤال ${_current + 1}/${_questions.length}',
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 20),
+            Text(q.text),
+            const SizedBox(height: 20),
+            ...List.generate(q.options.length, (i) {
+              return Container(
+                width: double.infinity,
+                margin: const EdgeInsets.symmetric(vertical: 8),
+                child: ElevatedButton(
+                  onPressed: () => _answer(i),
+                  child: Text(q.options[i]),
+                ),
+              );
+            })
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Question {
+  final String text;
+  final List<String> options;
+  final int answerIndex;
+
+  const _Question({
+    required this.text,
+    required this.options,
+    required this.answerIndex,
+  });
+}


### PR DESCRIPTION
## Summary
- track opened books with counter on home screen
- add banner carousel for in-app promotions
- introduce simple quiz screen with multiple choice questions

## Testing
- `apt-get update` *(fails: repository is not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973569bee4832aa4ee54b33df2ca86